### PR TITLE
Refactoring structure to keep settings in user home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ represented by the pull requests that fixed them. Critical items to know are:
 
 
 ## [master](https://github.com/snakemake/snakeface/tree/main) (master)
+ - moving snakeface settings and static to use home (0.0.19)
  - removing erroneous variables (0.0.18)
  - fixing async bug and adding missing template file (0.0.17)
  - removing extra dependencies for API (0.0.16)

--- a/docs/getting_started/example_workflow.rst
+++ b/docs/getting_started/example_workflow.rst
@@ -88,7 +88,9 @@ section.
 Running Snakeface
 =================
 
-At this point, from this working directory you can run Snakeface. For example, you
+At this point you can run snakeface. It should use the port and host that you've
+specified (localhost port 5000). If you need to change any of these settings, update
+the settings.yml file in ``~/.snakeface``. At this point, from this working directory you can run Snakeface. For example, you
 might run a :ref:`getting_started-notebook`. Make sure to select ``--use-conda``
 or else the environment above won't be properly sourced. This is one deviation from the main
 Snakemake tutorial, which has you install dependencies on the command line before running

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -7,12 +7,51 @@ Installation
 Snakeface can be installed and run from a virtual environment, or from a container.
 
 
+Install via pip
+===============
+
+Snakeface can be installed with pip.
+
+.. code:: console
+
+    $ pip install snakeface
+
+
+Once it's installed, you should be able to inspect the client!
+
+
+.. code-block:: console
+
+    $ snakeface --help
+
+
+The first thing you should do is run ``snakeface init``, which will create a 
+structure in your $HOME for snakeface settings, static files, and a local
+database.
+
+.. code-block:: console
+
+    $ snakeface init
+    Init complete. Settings are at /home/vanessa/.snakeface/settings.yml
+    tree ~/.snakeface/
+    /home/vanessa/.snakeface/
+    ├── data
+    └── static
+
+
+At this point you can inspect the settings file generated, and make any updates.
+When you run a notebook, this file will be updated with a secret key for the
+server, so you should keep this settings file private.  If you ever
+need to regenerate it from scratch, you can remove the file or entire
+folder and re-run snakeface init. See :ref:`getting_started-settings` for more detail.
+
+
 Virtual Environment
 ===================
 
 First, clone the repository code.
 
-.. code:: console
+.. code-block:: console
 
     $ git clone git@github.com:snakemake/snakeface.git
     $ cd snakeface
@@ -20,7 +59,7 @@ First, clone the repository code.
 
 Then you'll want to create a new virtual environment, and install dependencies.
 
-.. code:: console
+.. code-block:: console
 
     $ python -m venv env
     $ source env/bin/activate
@@ -32,64 +71,6 @@ And install Snakeface (from the repository directly)
 .. code:: console
  
     $ pip install -e .
-
-
-Install via pip
-===============
-
-Snakeface can also be installed with pip.
-
-.. code:: console
-
-    $ pip install snakeface
-
-
-Once it's installed, you should be able to inspect the client!
-
-
-.. code:: console
-
-    $ snakeface --help
-    usage: snakeface [-h] [--version] [--noreload] [--verbosity {0,1,2,3}]
-                     [--workdir [WORKDIR]] [--auth {token}] [--port PORT]
-                     [--verbose] [--log-disable-color] [--log-use-threads]
-                     [--force]
-                     [repo] [dest] {notebook} ...
-
-    Snakeface: interface to snakemake.
-
-    positional arguments:
-      repo                  Repository address and destination to deploy, e.g.,
-                            <source> <dest>
-      dest                  Path to clone the repository, should not exist.
-
-    optional arguments:
-      -h, --help            show this help message and exit
-      --version             print the version and exit.
-      --noreload            Tells Django to NOT use the auto-reloader.
-      --verbosity {0,1,2,3}
-                            Verbosity (0, 1, 2, 3).
-      --workdir [WORKDIR]   Specify the working directory.
-      --force               If the folder exists, force overwrite, meaning remove
-                            and replace.
-
-    SETTINGS:
-      --auth {token}        Authentication type to create for the interface,
-                            defaults to token.
-
-    NETWORKING:
-      --port PORT           Port to serve application on.
-
-    LOGGING:
-      --verbose             verbose output for logging.
-      --log-disable-color   Disable color for snakeface logging.
-      --log-use-threads     Force threads rather than processes.
-
-    actions:
-      subparsers for Snakeface
-
-      {notebook}            snakeface actions
-        notebook            run a snakeface notebook
 
 
 Setup

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-Django==3.0.14
+Django==3.1.9
 django-ratelimit==3.0.0
 django-extensions==3.0.2
 sendgrid==6.4.3
-snakemake
-snakeface
+snakemake[report]
 django-q==1.3.4
 # just for postgres
 psycopg2-binary==2.8.5

--- a/snakeface/client.py
+++ b/snakeface/client.py
@@ -5,6 +5,7 @@ __copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from snakeface.logger import setup_logger
+from snakeface.setup import init_snakeface
 from django.core.wsgi import get_wsgi_application
 from django.core import management
 from snakeface.version import __version__
@@ -37,6 +38,7 @@ def get_parser():
     parser.add_argument(
         "--verbosity",
         dest="verbosity",
+        type=int,
         help="Verbosity (0, 1, 2, 3).",
         choices=list(range(0, 4)),
         default=0,
@@ -104,6 +106,7 @@ def get_parser():
 
     # print version and exit
     subparsers.add_parser("notebook", help="run a snakeface notebook")
+    subparsers.add_parser("init", help="Create new settings in $HOME/.snakeface")
 
     return parser
 
@@ -128,11 +131,15 @@ def main():
         print(__version__)
         sys.exit(0)
 
-    # Do we want a notebook?
-    notebook = args.command == "notebook"
-    if notebook:
-        os.environ["SNAKEFACE_NOTEBOOK"] = "yes"
-        os.putenv("SNAKEFACE_NOTEBOOK", "yes")
+    # Currently we only support notebooks!
+    notebook = True
+
+    # Init snakeface settings in home if they don't exist
+    settings_file = init_snakeface(notebook)
+
+    # If we just needed to do that, exit
+    if args.command == "init":
+        sys.exit("Init complete. Settings are at %s" % settings_file)
 
     # If a working directory is set
     if not args.workdir or args.workdir == ".":

--- a/snakeface/client.py
+++ b/snakeface/client.py
@@ -59,7 +59,10 @@ def get_parser():
 
     network_group = parser.add_argument_group("NETWORKING")
     network_group.add_argument(
-        "--port", dest="port", help="Port to serve application on.", default=5000
+        "--port", dest="port", help="Port to serve application on."
+    )
+    network_group.add_argument(
+        "--host", dest="host", help="Domain name to serve application."
     )
 
     # Logging
@@ -131,15 +134,21 @@ def main():
         print(__version__)
         sys.exit(0)
 
-    # Currently we only support notebooks!
-    notebook = True
-
     # Init snakeface settings in home if they don't exist
-    settings_file = init_snakeface(notebook)
+    settings = init_snakeface()
+
+    # Currently we only support notebooks!
+    settings.NOTEBOOK = True
+    settings.save()
+
+    # Default to port on command line, then settings, then 5000
+    port = args.port or settings.DOMAIN_PORT or 5000
+    host = args.host or settings.DOMAIN_NAME or "127.0.0.1"
+    host = "%s:%s" % (host, port)
 
     # If we just needed to do that, exit
     if args.command == "init":
-        sys.exit("Init complete. Settings are at %s" % settings_file)
+        sys.exit("Init complete. Settings are at %s" % settings.settings_file)
 
     # If a working directory is set
     if not args.workdir or args.workdir == ".":
@@ -169,7 +178,7 @@ def main():
         "collectstatic", verbosity=args.verbosity, interactive=False
     )
     management.call_command(
-        "runserver", args.port, verbosity=args.verbosity, noreload=not args.noreload
+        "runserver", host, verbosity=args.verbosity, noreload=not args.noreload
     )
     sys.exit(0)
 

--- a/snakeface/settings.yml
+++ b/snakeface/settings.yml
@@ -51,7 +51,7 @@ ENVIRONMENT: test
 HELP_CONTACT_URL: https://github.com/snakemake/snakeface/issues
 SENDGRID_API_KEY: null
 SENDGRID_SENDER_EMAIL: null
-DOMAIN_NAME: http://127.0.0.1
+DOMAIN_NAME: 127.0.0.1
 DOMAIN_PORT: 5000
 REQUIRE_AUTH: true
 

--- a/snakeface/settings.yml
+++ b/snakeface/settings.yml
@@ -1,5 +1,5 @@
-# The snakeface settings.yml file is kept alongside the install location,
-# meaning that it should only be editable by an owner or system administrator
+# This is a base settings.yml file that will be added to the user home
+# on first use of snakeface.
 
 # How to fill in fields? -------------------------------------------------------
 # For fields that you want to leave undefined, leave them as null
@@ -44,7 +44,7 @@ EXECUTOR_GA4GH_TES: null
 # Disable other argument groups by setting these to non null
 DISABLE_SINGULARITY: null
 DISABLE_CONDA: null
-DISABLE_NOTEBOOKS: true
+DISABLE_NOTEBOOKS: null
 
 # Global server settings
 ENVIRONMENT: test

--- a/snakeface/setup.py
+++ b/snakeface/setup.py
@@ -88,16 +88,10 @@ def init_home():
     Path(init_file).touch()
 
 
-def init_snakeface(notebook=True):
+def init_snakeface():
     """
     Create all directories that should hold static and media files
     """
     init_home()
     user_settings = init_settings()
-
-    # If the user requested a notebook, add to settings
-    if notebook:
-        cfg = Settings(user_settings)
-        cfg.NOTEBOOK = True
-        cfg.save()
-    return user_settings
+    return Settings(user_settings)

--- a/snakeface/setup.py
+++ b/snakeface/setup.py
@@ -1,0 +1,103 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
+
+import os
+import shutil
+import yaml
+from snakeface.logger import logger
+from pathlib import Path
+from datetime import datetime
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+USER_HOME = os.path.expanduser(os.path.join("~", ".snakeface"))
+USER_SETTINGS = os.path.join(USER_HOME, "settings.yml")
+
+STATIC_ROOT = os.path.join(USER_HOME, "static")
+MEDIA_ROOT = os.path.join(USER_HOME, "data")
+USER_DATABASE = os.path.join(USER_HOME, "db.sqlite3")
+
+MIGRATIONS_MODULE = "snakefacedb"
+MIGRATIONS_MODULE_PATH = os.path.join(USER_HOME, MIGRATIONS_MODULE)
+
+
+# Read in the settings file to get settings
+class Settings:
+    """convert a dictionary of settings (from yaml) into a class"""
+
+    def __init__(self, settings_file):
+        self.settings_file = settings_file
+        with open(settings_file, "r") as fd:
+            self.load(yaml.load(fd.read(), Loader=yaml.FullLoader))
+
+    def save(self):
+        """
+        Save the settings file if there are changes
+        """
+        with open(self.settings_file, "w") as fd:
+            yaml.dump(self.__dict__, fd)
+
+    def load(self, dictionary):
+        for key, value in dictionary.items():
+            setattr(self, key, value)
+        setattr(self, "UPDATED_AT", datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+    def __str__(self):
+        return "[snakeface-settings]"
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __getattr__(self, key):
+        return self.__dict__.get(key)
+
+    def __iter__(self):
+        for key, value in self.__dict__.items():
+            yield key, value
+
+
+def init_settings():
+    """
+    Create user settings in $HOME if they don't exist.
+    """
+    settings_file = os.path.join(BASE_DIR, "settings.yml")
+    if not os.path.exists(settings_file):
+        logger.exit(
+            "Global settings file settings.yml is missing in the install directory."
+        )
+    if not os.path.exists(USER_HOME):
+        logger.info("Creating user snakeface home at %s" % USER_HOME)
+        os.makedirs(USER_HOME)
+
+    if not os.path.exists(USER_SETTINGS):
+        logger.info("Creating user settings at %s" % USER_SETTINGS)
+        shutil.copyfile(settings_file, USER_SETTINGS)
+    return USER_SETTINGS
+
+
+def init_home():
+    """
+    Create snakeface use home
+    """
+    if not os.path.exists(USER_HOME):
+        os.makedirs(USER_HOME)
+    for dirname in [STATIC_ROOT, MEDIA_ROOT, MIGRATIONS_MODULE_PATH]:
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+    init_file = os.path.join(MIGRATIONS_MODULE_PATH, "__init__.py")
+    Path(init_file).touch()
+
+
+def init_snakeface(notebook=True):
+    """
+    Create all directories that should hold static and media files
+    """
+    init_home()
+    user_settings = init_settings()
+
+    # If the user requested a notebook, add to settings
+    if notebook:
+        cfg = Settings(user_settings)
+        cfg.NOTEBOOK = True
+        cfg.save()
+    return user_settings

--- a/snakeface/version.py
+++ b/snakeface/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.18"
+__version__ = "0.0.19"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "snakeface"


### PR DESCRIPTION
This is a quick refactor to address some problems discussed in #21. I think the issue this user is facing is that the install was messy - we shouldn't require the user to clone and install locally, it should just work with pip install snakeface, and then we write whatever we need to the user home. This is optimized for the notebook use case, which (since we don't have other plugins for auth yet) I think is safe to focus on for now. This means that:

 - A ~/.snakeface directory is created, snakeface home
 - We write the sqlite database here, migrations, user settings, and static files
 - The default is now to run a 

I think we could improve things by using ruamel.yaml (which preserves comments) but this should be good for a first. shot.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>